### PR TITLE
Correct link to required tool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ The HTML produced differs from the one you'd get from pdftohtml in these ways:
 * The HTML produced is modern XHTML, not ancient HTML 3 with an explicit dark-grey
   bgcolor on the <BODY> (what's up with that???).
 
-.. _pdftohtml: http://pdftohtml.sourceforge.net/
+.. _pdftohtml: https://poppler.freedesktop.org/
 
 
 Usage


### PR DESCRIPTION
Removed link to http://pdftohtml.sourceforge.net/ and replaced with https://poppler.freedesktop.org/

Its not clear to me that pdftohtml.sourceforge.net supports all the command line arguments needed.